### PR TITLE
Add markdown bar if Reflect API is present

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2869,11 +2869,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
-    "harmony-reflect": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
-      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA=="
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",

--- a/js/package.json
+++ b/js/package.json
@@ -5,7 +5,6 @@
     "@github/markdown-toolbar-element": "^0.1.1",
     "@webcomponents/custom-elements": "^1.2.1",
     "flarum-webpack-config": "0.1.0-beta.10",
-    "harmony-reflect": "^1.6.1",
     "mdarea": "^0.0.10",
     "webpack": "^4.26.0",
     "webpack-cli": "^3.1.2"

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -2,12 +2,17 @@ import { extend } from 'flarum/extend';
 import TextEditor from 'flarum/components/TextEditor';
 import icon from 'flarum/helpers/icon';
 
-import '@webcomponents/custom-elements';
-import 'harmony-reflect';
-import '@github/markdown-toolbar-element';
-import MarkdownArea from 'mdarea/mdarea.js';
+let MarkdownArea;
+
+if (window.Reflect) {
+  require('@webcomponents/custom-elements');
+  require('@github/markdown-toolbar-element');
+  MarkdownArea = require('mdarea/mdarea.js');
+}
 
 app.initializers.add('flarum-markdown', function(app) {
+  if (!MarkdownArea) return;
+
   let index = 1;
 
   extend(TextEditor.prototype, 'init', function() {


### PR DESCRIPTION
- Removed `harmony-reflect` package
- Check for presence of `Reflect` before importing custom elements pollyfill, markdown bar, and markdown area
    - Chose to import all 3 then because it doesn't make sense to run the code if it can't be used

Ref flarum/core#1702

![firefox](https://cdn.discordapp.com/attachments/519493891087400971/565659649614020638/unknown.png)
![ie](https://cdn.discordapp.com/attachments/519493891087400971/565659693532577805/unknown.png)