### PR TITLE
fix: re-use of texteditor with markdown ext breaks markdown toolbar items

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -32,23 +32,26 @@ const styles = {
   spoiler: { prefix: '>!', suffix: '!<', blockPrefix: '>! ', multiline: true, trimFirst: true },
 };
 
-const applyStyle = (id, composerElement) => {
-  styleSelectedText(composerElement, styles[id]);
+const applyStyle = (id, editorDriver) => {
+  // This is a nasty hack that breaks encapsulation of the editor.
+  // In future releases, we'll need to tweak the editor driver interface
+  // to support triggering events like this.
+  styleSelectedText(editorDriver.el, styles[id]);
 };
 
-function makeShortcut(id, key, composerElement) {
+function makeShortcut(id, key, editorDriver) {
   return function (e) {
     if (e.key === key && ((e.metaKey && modifierKey === '⌘') || (e.ctrlKey && modifierKey === 'ctrl'))) {
       e.preventDefault();
-      applyStyle(id, composerElement);
+      applyStyle(id, editorDriver);
     }
   };
 }
 
 app.initializers.add('flarum-markdown', function (app) {
   extend(BasicEditorDriver.prototype, 'keyHandlers', function (items) {
-    items.add('bold', makeShortcut('bold', 'b', this.el));
-    items.add('italic', makeShortcut('italic', 'i', this.el));
+    items.add('bold', makeShortcut('bold', 'b', this));
+    items.add('italic', makeShortcut('italic', 'i', this));
   });
 
   extend(TextEditor.prototype, 'toolbarItems', function (items) {
@@ -57,7 +60,7 @@ app.initializers.add('flarum-markdown', function (app) {
     };
 
     const makeApplyStyle = (id) => {
-      return () => applyStyle(id, this.attrs.composer.editor.el);
+      return () => applyStyle(id, this.attrs.composer.editor);
     };
 
     items.add(

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -7,7 +7,8 @@
  * https://github.com/github/markdown-toolbar-element/blob/master/LICENSE
  */
 
-import { extend } from 'flarum/extend';
+import app from 'flarum/forum/app';
+import { extend } from 'flarum/common/extend';
 import TextEditor from 'flarum/common/components/TextEditor';
 import BasicEditorDriver from 'flarum/common/utils/BasicEditorDriver';
 import styleSelectedText from 'flarum/common/utils/styleSelectedText';
@@ -31,26 +32,23 @@ const styles = {
   spoiler: { prefix: '>!', suffix: '!<', blockPrefix: '>! ', multiline: true, trimFirst: true },
 };
 
-const applyStyle = (id) => {
-  // This is a nasty hack that breaks encapsulation of the editor.
-  // In future releases, we'll need to tweak the editor driver interface
-  // to support triggering events like this.
-  styleSelectedText(app.composer.editor.el, styles[id]);
+const applyStyle = (id, composerElement) => {
+  styleSelectedText(composerElement, styles[id]);
 };
 
-function makeShortcut(id, key) {
+function makeShortcut(id, key, composerElement) {
   return function (e) {
     if (e.key === key && ((e.metaKey && modifierKey === '⌘') || (e.ctrlKey && modifierKey === 'ctrl'))) {
       e.preventDefault();
-      applyStyle(id);
+      applyStyle(id, composerElement);
     }
   };
 }
 
 app.initializers.add('flarum-markdown', function (app) {
   extend(BasicEditorDriver.prototype, 'keyHandlers', function (items) {
-    items.add('bold', makeShortcut('bold', 'b'));
-    items.add('italic', makeShortcut('italic', 'i'));
+    items.add('bold', makeShortcut('bold', 'b', this.el));
+    items.add('italic', makeShortcut('italic', 'i', this.el));
   });
 
   extend(TextEditor.prototype, 'toolbarItems', function (items) {
@@ -59,7 +57,7 @@ app.initializers.add('flarum-markdown', function (app) {
     };
 
     const makeApplyStyle = (id) => {
-      return () => applyStyle(id);
+      return () => applyStyle(id, this.attrs.composer.editor.el);
     };
 
     items.add(


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
Re-use of the TextEditor outside the standard composer, along with the Markdown extension, results in errors since Markdown is hard-coded to use `app.composer`.

This PR switched `app.composer` out for a dynamic system which fetches the appropriate data from the current TextEditor instance state.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
N/A

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

![](https://user-images.githubusercontent.com/7406822/147663793-bfe37d53-e894-4ed4-8303-32bf12dccb57.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
