### PR TITLE
chore. Add target _blank to links

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -26,6 +26,28 @@ return [
             // Overwrite the default inline spoiler so that it is compatible
             // with more styling for children in an external stylesheet.
             $config->tags['ispoiler']->template = '<span class="spoiler" data-s9e-livepreview-ignore-attrs="class" onclick="removeAttribute(\'class\')"><xsl:apply-templates/></span>';
+            
+            // Add support for {:target="_blank"} in links
+            // This will match [text](url){:target="_blank"}
+            if (isset($config->tags['URL'])) {
+                // Modify the URL tag template to support target attribute
+                $config->tags['URL']->template = '<a href="{@url}"><xsl:if test="@target"><xsl:attribute name="target"><xsl:value-of select="@target"/></xsl:attribute></xsl:if><xsl:apply-templates/></a>';
+                
+                // Add the target attribute to the tag
+                $config->tags['URL']->attributes->add('target')->filterChain->append('#identifier');
+            }
+        })
+        ->render(function ($renderer, $context, $xml, $request) {
+            // Post-process the XML to extract {:target="_blank"} attributes
+            $xml = preg_replace_callback(
+                '/<URL url="([^"]*)">(.*?)\{:target="_blank"\}<\/URL>/',
+                function ($matches) {
+                    return '<URL url="' . $matches[1] . '" target="_blank">' . $matches[2] . '</URL>';
+                },
+                $xml
+            );
+            
+            return $xml;
         }),
 
     new Extend\Locales(__DIR__.'/locale'),

--- a/js/src/common/index.js
+++ b/js/src/common/index.js
@@ -26,6 +26,7 @@ const styles = {
   quote: { prefix: '> ', multiline: true, surroundWithNewlines: true },
   code: { prefix: '`', suffix: '`', blockPrefix: '```', blockSuffix: '```' },
   link: { prefix: '[', suffix: '](https://)', replaceNext: 'https://', scanFor: 'https?://' },
+  link_blank: { prefix: '[', suffix: '](https://){:target="_blank"}', replaceNext: 'https://', scanFor: 'https?://' },
   image: { prefix: '![', suffix: '](https://)', replaceNext: 'https://', scanFor: 'https?://' },
   unordered_list: { prefix: '- ', multiline: true, surroundWithNewlines: true },
   ordered_list: { prefix: '1. ', multiline: true, orderedList: true },
@@ -71,6 +72,7 @@ function markdownToolbarItems(oldFunc) {
   items.add('spoiler', <MarkdownButton title={tooltip('spoiler')} icon="fas fa-exclamation-triangle" onclick={makeApplyStyle('spoiler')} />, 500);
   items.add('code', <MarkdownButton title={tooltip('code')} icon="fas fa-code" onclick={makeApplyStyle('code')} />, 400);
   items.add('link', <MarkdownButton title={tooltip('link')} icon="fas fa-link" onclick={makeApplyStyle('link')} />, 300);
+  items.add('link_blank', <MarkdownButton title={tooltip('link_blank')} icon="fas fa-external-link-alt" onclick={makeApplyStyle('link_blank')} />, 290);
   items.add('image', <MarkdownButton title={tooltip('image')} icon="fas fa-image" onclick={makeApplyStyle('image')} />, 200);
   items.add(
     'unordered_list',

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -7,6 +7,7 @@ flarum-markdown:
       image_tooltip: Add an image
       italic_tooltip: Add italic text
       link_tooltip: Add a link
+      link_blank_tooltip: Add a link (opens in new tab)
       ordered_list_tooltip: Add a numbered list
       quote_tooltip: Insert a quote
       spoiler_tooltip: Insert a spoiler

--- a/locale/es.yml
+++ b/locale/es.yml
@@ -1,0 +1,15 @@
+flarum-markdown:
+  lib:
+    composer:
+      bold_tooltip: Añadir texto en negrita
+      code_tooltip: Insertar código
+      header_tooltip: Agregar texto de encabezado
+      image_tooltip: Añadir una imagen
+      italic_tooltip: Añadir texto en cursiva
+      link_tooltip: Añadir un enlace
+      link_blank_tooltip: Añadir un enlace (se abre en una nueva pestaña)
+      ordered_list_tooltip: Agregar una lista numerada
+      quote_tooltip: Insertar una cita
+      spoiler_tooltip: Insertar un spoiler
+      strikethrough_tooltip: Agregar texto tachado
+      unordered_list_tooltip: Agregar una lista con viñetas


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes #0000**

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
What I want to achieve with this pull request is that the links can have the corresponding HTML tag, so that they can be opened in another tab.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
This is my first time working with the community, so I may need some guidance, but if necessary, I'm willing to make any necessary changes to get the code working and merged.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
