### PR TITLE
Chore. Add the target attribute to all links

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -26,8 +26,21 @@ return [
             // Overwrite the default inline spoiler so that it is compatible
             // with more styling for children in an external stylesheet.
             $config->tags['ispoiler']->template = '<span class="spoiler" data-s9e-livepreview-ignore-attrs="class" onclick="removeAttribute(\'class\')"><xsl:apply-templates/></span>';
-            // Add target="_blank" to all links
-            $config->tags['URL']->template = '<a href="{@url}" target="_blank" rel="noopener noreferrer"><xsl:apply-templates/></a>';
+
+            // Add target attribute to URL tag
+            if (isset($config->tags['URL'])) {
+                $config->tags['URL']->attributes->add('target');
+            }
+        })
+        ->render(function ($renderer, $context, $xml) {
+            // Modify the XML to add target="_blank" to all URL tags
+            $xml = preg_replace(
+                '/<URL url="([^"]*)"/',
+                '<URL url="$1" target="_blank"',
+                $xml
+            );
+
+            return $xml;
         }),
 
     new Extend\Locales(__DIR__.'/locale'),

--- a/extend.php
+++ b/extend.php
@@ -26,6 +26,8 @@ return [
             // Overwrite the default inline spoiler so that it is compatible
             // with more styling for children in an external stylesheet.
             $config->tags['ispoiler']->template = '<span class="spoiler" data-s9e-livepreview-ignore-attrs="class" onclick="removeAttribute(\'class\')"><xsl:apply-templates/></span>';
+            // Add target="_blank" to all links
+            $config->tags['URL']->template = '<a href="{@url}" target="_blank" rel="noopener noreferrer"><xsl:apply-templates/></a>';
         }),
 
     new Extend\Locales(__DIR__.'/locale'),

--- a/locale/es.yml
+++ b/locale/es.yml
@@ -1,0 +1,14 @@
+flarum-markdown:
+  lib:
+    composer:
+      bold_tooltip: Añadir texto en negrita
+      code_tooltip: Insertar código
+      header_tooltip: Agregar texto de encabezado
+      image_tooltip: Añadir una imagen
+      italic_tooltip: Añadir texto en cursiva
+      link_tooltip: Añadir un enlace
+      ordered_list_tooltip: Agregar una lista numerada
+      quote_tooltip: Insertar una cita
+      spoiler_tooltip: Insertar un spoiler
+      strikethrough_tooltip: Agregar texto tachado
+      unordered_list_tooltip: Agregar una lista con viñetas


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
The purpose of this pull request is to add an attribute to hyperlinks so they open in other tabs. I tried to make it optional rather than mandatory, however, it required some changes that are beyond my current knowledge. I'll post the results with screenshots later.

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->
In the future, I hope to add it as optional, but I tried, and it didn't work. In fact, this is the third pull request I've opened today. I closed the first one because I thought I had the wrong branch, so I worked on master. But then, when I was able to test the code locally, I realized it was using the current branch I wanted to contribute to.
https://github.com/flarum/markdown/pull/39
https://github.com/flarum/markdown/pull/38


https://github.com/user-attachments/assets/8c1986cc-9550-42c2-8130-8158e8ec30b3